### PR TITLE
point source to "wearetechnative"

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Currently no known solution other than deleting and recreating the ASG.
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_eip_lambda"></a> [eip\_lambda](#module\_eip\_lambda) | ./eip_lambda | n/a |
-| <a name="module_iam_role"></a> [iam\_role](#module\_iam\_role) | ../identity_and_access_management/iam_role | n/a |
+| <a name="module_iam_role"></a> [iam\_role](#module\_iam\_role) | git@github.com:wearetechnative/terraform-aws-iam-role | 9a975f62956b6c4f2593c169d06d1cfe8aad36be |
 
 ## Resources
 

--- a/eip_lambda/main.tf
+++ b/eip_lambda/main.tf
@@ -1,7 +1,7 @@
 # stolen from https://github.com/hashicorp/terraform/issues/8344
 
 module "lambda" {
-  source = "git@github.com:TechNative-B-V/terraform-aws-module-lambda?ref=c63e985e3926e359612a6c398a635d6a9fea5653"
+  source = "git@github.com:wearetechnative/terraform-aws-lambda?ref=ce4e37b22df162b0243a8f9333c010bdaf6d8ead"
 
   name = var.name
   role_arn = module.iam_role.role_arn

--- a/eip_lambda/role.tf
+++ b/eip_lambda/role.tf
@@ -1,5 +1,5 @@
 module "iam_role" {
-  source = "git@github.com:TechNative-B-V/terraform-aws-module-iam-role?ref=81c45f4d87bace3e990e64b92030292ac2fc480c" # change to commit or version later
+  source = "git@github.com:wearetechnative/terraform-aws-iam-role?ref=9a975f62956b6c4f2593c169d06d1cfe8aad36be"
 
   role_name = var.name
   role_path = "/${var.module_resource_name_prefix}/"

--- a/instance_profile.tf
+++ b/instance_profile.tf
@@ -6,7 +6,7 @@ resource "aws_iam_instance_profile" "this" {
 module "iam_role" {
   count = var.instance_role_name == null ? 1 : 0
 
-  source = "git@github.com:TechNative-B-V/terraform-aws-module-iam-role?ref=81c45f4d87bace3e990e64b92030292ac2fc480c" # change to commit or version later
+  source = "git@github.com:wearetechnative/terraform-aws-iam-role?ref=9a975f62956b6c4f2593c169d06d1cfe8aad36be"
 
   role_name = local.module_resource_name
   role_path = "/${local.module_resource_name_prefix}/"


### PR DESCRIPTION


They moved to wearetechnative for a reason, let's use the proper source.